### PR TITLE
Support Cmd+D shortcut for selecting next occurrence of the selected word.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -571,6 +571,7 @@
 		<script src="lib/codemirror/addon/hint/html-hint.js"></script>
 		<script src="lib/codemirror/addon/hint/css-hint.js"></script>
 		<script src="lib/codemirror/addon/selection/active-line.js"></script>
+		<script src="lib/codemirror/addon/search/searchcursor.js"></script>
 
 		<script src="lib/codemirror/mode/xml/xml.js"></script>
 		<script src="lib/codemirror/mode/javascript/javascript.js"></script>


### PR DESCRIPTION
Add search/searchcursor to support Cmd+D shortcut for selecting next occurrence of the selected word. Fixes #196 