### PR TITLE
 Add check for development environment in `utils.js`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -15,7 +15,12 @@ window.chrome.i18n = {
 
 window.$all = selector => [...document.querySelectorAll(selector)];
 window.IS_EXTENSION = !!window.chrome.extension;
-export const BASE_PATH = window.chrome.extension || window.DEBUG ? '/' : '/app';
+export const BASE_PATH =
+	window.chrome.extension ||
+	window.DEBUG ||
+	process.env.NODE_ENV == 'development'
+		? '/'
+		: '/app';
 
 var alphaNum = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,7 @@ window.IS_EXTENSION = !!window.chrome.extension;
 export const BASE_PATH =
 	window.chrome.extension ||
 	window.DEBUG ||
-	process.env.NODE_ENV == 'development'
+	process.env.NODE_ENV === 'development'
 		? '/'
 		: '/app';
 


### PR DESCRIPTION
Check the value of `process.env.NODE_ENV` before setting `BASE_PATH` i n`utils.js`. If equal to `development`, set to `/` rather than `/app`

fixes #355 