### PR TITLE
fix-382-missing-event-tracking-for-usingPreview

### DIFF
--- a/src/components/ContentWrap.jsx
+++ b/src/components/ContentWrap.jsx
@@ -115,7 +115,7 @@ export default class ContentWrap extends Component {
 
 				// Track when people actually are working.
 				trackEvent.previewCount = (trackEvent.previewCount || 0) + 1;
-				if (trackEvent.previewCount === 4) {
+				if (trackEvent.previewCount % 4 === 0) {
 					trackEvent('fn', 'usingPreview');
 				}
 			}


### PR DESCRIPTION
Current implementation will only fire the event once in a lifetime.

#382 