### PR TITLE
Fixed web app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Web-Maker** is an offline playground for your web experiments. Something like CodePen or JSFiddle, but much more faster and offline supported because it runs completely on your system.
 
-### [Open Web App](https://webmakerapp.com/app/) (Recommended: More features. More fun!)
+### [Open Web App](https://webmaker.app/app/) (Recommended: More features. More fun!)
 
 or
 


### PR DESCRIPTION
Web app link in README was still pointing to the old version. Now points to new version of the app. I manually verified that the link works correctly in this PR.