### PR TITLE
strictly mention node version 10.22.1 in package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
 		"react-inspector": "^2.3.0",
 		"split.js": "1.3.4"
 	},
+	"engines": {
+		"node": "10.22.1",
+		"npm": "6.14.6"
+	},
 	"jest": {
 		"verbose": true,
 		"setupFiles": [


### PR DESCRIPTION
Mentioned node version under "engines" field and created a .npmrc file to show an error on terminal if wrong version of node is used