### PR TITLE
(v5) fix top header buttons misaligned

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,3 @@
 import App from './components/app.jsx';
 
-import './lib/codemirror/lib/codemirror.css';
-import './lib/codemirror/addon/hint/show-hint.css';
-import './lib/codemirror/addon/fold/foldgutter.css';
-import './lib/codemirror/addon/dialog/dialog.css';
-import './lib/hint.min.css';
-import './lib/inlet.css';
-
 export default App;


### PR DESCRIPTION
Fixes: #498 

The style sheets are already included in the `src/index.html`  so we can remove the imports in the `index.js`

https://github.com/chinchang/web-maker/blob/887cc68943f2cbc7b4d1e603769e3701ea0c78d1/src/index.html#L34-L41

Currently, the `master` branch doesn't include those in the `src/index.js` file:

https://github.com/chinchang/web-maker/blob/887cc68943f2cbc7b4d1e603769e3701ea0c78d1/src/index.js#L1-L3

**Before:**
![image](https://user-images.githubusercontent.com/51032928/157379328-40846b5d-833a-4182-97c8-6c9b5990cfa3.png)

**After:**
![image](https://user-images.githubusercontent.com/51032928/157379386-4a27aa2f-ca3e-4e8d-a83f-50e9525218d5.png)
