### PR TITLE
(v5) fix top header buttons misaligned

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -66,7 +66,6 @@ import {
 	SHOW_KEYBOARD_SHORTCUTS_EVENT
 } from '../commands';
 import { commandPaletteService } from '../commandPaletteService';
-import './../style.css';
 
 import { I18nProvider } from '@lingui/react';
 

--- a/src/index.html
+++ b/src/index.html
@@ -35,24 +35,11 @@
 			}
 		</style>
 
-		<!-- build:css vendor.css -->
-		<link rel="stylesheet" href="lib/codemirror/lib/codemirror.css" />
-		<link rel="stylesheet" href="lib/codemirror/addon/hint/show-hint.css" />
-		<link rel="stylesheet" href="lib/codemirror/addon/fold/foldgutter.css" />
-		<link rel="stylesheet" href="lib/codemirror/addon/dialog/dialog.css" />
-		<link rel="stylesheet" href="lib/hint.min.css" />
-		<link rel="stylesheet" href="lib/inlet.css" />
-		<!-- endbuild -->
-
 		<link
 			rel="stylesheet"
 			id="editorThemeLinkTag"
 			href="lib/codemirror/theme/monokai.css"
 		/>
-
-		<!-- build:css style.css -->
-		<link rel="stylesheet" href="style.css" />
-		<!-- endbuild -->
 
 		<style id="fontStyleTemplate" type="template">
 			@font-face {

--- a/src/index.js
+++ b/src/index.js
@@ -6,5 +6,6 @@ import './lib/codemirror/addon/fold/foldgutter.css';
 import './lib/codemirror/addon/dialog/dialog.css';
 import './lib/hint.min.css';
 import './lib/inlet.css';
+import './style.css';
 
 export default App;


### PR DESCRIPTION
Fixes: #498 

Ideally, we would want the bundler to bundle the CSS files, and hence we should include the stylesheets in the `index.js`. So we can remove the linked CSS files in the `index.html`.

The main issue regarding the misalignment was that `style.css` was being overridden by `hint.min.css`. There was one import of the `style.css` in `src/components/app.jsx` which was the culprit. So removed it from there and put it together with the other imports in the `index.js`. Also maintained the order such that `style.css` is not overridden anymore. This fixes the alignment issue. 


**Before**
![image](https://user-images.githubusercontent.com/51032928/157889095-f83647d0-afd8-4622-bbb2-945de4b8a00e.png)

**After**
![image](https://user-images.githubusercontent.com/51032928/157889118-ab807ca9-a4f0-40c5-a6d0-60929801f742.png)
