### PR TITLE
(v5) fix detached preview not working in Files mode and some nits

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "4.2.0",
 	"description": "A blazing fast & offline web playground",
 	"scripts": {
-		"start": "npm run -s dev",
+		"start": "concurrently --kill-others \"gulp start-preview-server\" \"npm run -s dev\"",
 		"build": "preact build --template src/index.html --prerender false",
 		"dev": "preact watch --template src/index.html",
 		"serve-website": "cd packages/website; npm start",
@@ -41,6 +41,7 @@
 		"babel-eslint": "^7.2.3",
 		"babel-minify": "^0.2.0",
 		"babel-plugin-macros": "^2.6.1",
+		"concurrently": "^7.0.0",
 		"eslint": "^4.9.0",
 		"eslint-config-prettier": "^2.3.0",
 		"eslint-config-synacor": "^2.0.2",

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -31,7 +31,7 @@ const Modal = ({
 	useEffect(() => {
 		window.addEventListener('keydown', onKeyDownHandler);
 		return () => {
-			window.removeEventListener('keydown', this.onKeyDownHandler.bind(this));
+			window.removeEventListener('keydown', onKeyDownHandler.bind(this));
 			if (focusGrabberRef.current) {
 				focusGrabberRef.current.remove();
 				focusGrabberRef.current = null;

--- a/src/detached-window.js
+++ b/src/detached-window.js
@@ -9,7 +9,7 @@ window.addEventListener('message', e => {
 			frame.contentDocument.close();
 		}, 10);
 	}
-	if (e.data && e.data.url && e.data.url.match(/preview\.html/)) {
+	if (e.data && e.data.url && e.data.url.match(/index\.html/)) {
 		document.querySelector('iframe').src = e.data.url;
 	}
 


### PR DESCRIPTION
Fixes: #443 

**1. Detached Preview Fix**

The iframe in the case of Files Mode has src set to `http://localhost:7888/index.html`. When we click on detached preview, it opens a new window and checks for two cases, one for the normal mode and the other for the Files Mode. In the latter it had the condition;

```js
	if (e.data && e.data.url && e.data.url.match(/preview\.html/)) {
		document.querySelector('iframe').src = e.data.url;
	}
```

but as we mentioned before the src ends with `index.html`. So replacing the `preview` with `index` fixed the issue.

https://user-images.githubusercontent.com/51032928/158008382-549db3ae-6390-4ad0-906b-eb03845a8164.mp4


**2. Small fix in `src/components/Modal.jsx`.**

Currently, in the `v5` branch we see this error in the "files mode".

![image](https://user-images.githubusercontent.com/51032928/158007832-9427f195-d896-4f49-8127-5db53672c853.png)

The fix was to remove the `this` from the `this.onKeyDownHandler`. We have shifted to functional components in `Modal.jsx` in `v5`. 

**3. Added a new dev dependency `concurrently`**

When we are dealing with Files Mode in development. We need to have a separate server serving the `preview.html`. We do that using `gulp`. Running `gulp start-preview-server` achieves this:

![image](https://user-images.githubusercontent.com/51032928/158008011-753adc0a-b907-4f01-81f8-0e72594cbc6a.png)

So we have to keep this running in the background and then run the `npm run dev` in another terminal which is a lot of hassle. For that, we use this tool [concurrently](https://www.npmjs.com/package/concurrently). 

Now, we can just run `npm run start` and it will start the gulp preview server and the application together. We are using the flag `--kill-others` so that it kills other processes if one exits (when we press Ctrl + C) or dies.

![image](https://user-images.githubusercontent.com/51032928/158008427-9a6cec44-931c-4bee-9008-9ef0d793f608.png)
