### PR TITLE
Add functionality of coming back from full preview in files mode

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -286,7 +286,7 @@ export default class Footer extends Component {
 								onClick={this.layoutBtnClickhandler.bind(this, 4)}
 								id="layoutBtn4"
 								class="mode-btn hint--top-left hint--rounded hide-on-mobile"
-								aria-label={i18n._(t`Switch to full screen preview`)}
+								aria-label={i18n._(t`Toggle full screen preview`)}
 							>
 								<svg viewBox="0 0 100 100">
 									<rect x="0" y="0" width="100" height="100" />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -285,7 +285,7 @@ export default class Footer extends Component {
 							<button
 								onClick={this.layoutBtnClickhandler.bind(this, 4)}
 								id="layoutBtn4"
-								class="mode-btn hint--top-left hint--rounded hide-in-file-mode hide-on-mobile"
+								class="mode-btn hint--top-left hint--rounded hide-on-mobile"
 								aria-label={i18n._(t`Switch to full screen preview`)}
 							>
 								<svg viewBox="0 0 100 100">

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -735,6 +735,9 @@ export default class App extends Component {
 	}
 
 	layoutBtnClickHandler(layoutId) {
+		if (layoutId === this.state.currentLayoutMode) {
+			layoutId = 2;
+		}
 		this.saveSetting('layoutMode', layoutId);
 		trackEvent('ui', 'toggleLayoutClick', layoutId);
 		this.toggleLayout(layoutId);


### PR DESCRIPTION
Fix #397 

**Before:**
- Button to enable Full-Screen Preview was disabled

**After:**
- User can double click on Full-Screen Preview in Files Mode to toggle between the two layouts. (one with the files shown and one without)
- In the normal mode too, if the user double clicks on any layout mode, they will be taken to `layout 2`.