### PR TITLE
v5: Fix Type-Error on opening Modals

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -46,7 +46,7 @@ const Modal = ({
 		if (show) {
 			// HACK: refs will evaluate on next tick due to portals
 			setTimeout(() => {
-				const closeButton = this.overlayEl.querySelector(
+				const closeButton = overlayRef.current.querySelector(
 					'.js-modal__close-btn'
 				);
 				if (closeButton) {


### PR DESCRIPTION
Fixes: #507 

The `ref` was assigned to `overlayRef` not `overlayEl`. We can access the element with the `current` attribute. Then apply `querySelector`. 

> a reference to the node becomes accessible at the **current** attribute of the ref.
_Source:_ https://reactjs.org/docs/refs-and-the-dom.html#accessing-refs

https://github.com/chinchang/web-maker/blob/ea740823da9064752a9d6fda117b10573a8d05bb/src/components/Modal.jsx#L81-L87

Final Result:

![image](https://user-images.githubusercontent.com/51032928/161390445-223fe606-0a87-4d33-aa04-7a5be567b00d.png)
