### PR TITLE
try saving with refreshed ids when importing to DB fails

### DIFF
--- a/src/itemService.js
+++ b/src/itemService.js
@@ -1,5 +1,5 @@
 import { deferred } from './deferred';
-import { log } from './utils';
+import { log, refreshItemIds } from './utils';
 import {
 	collection,
 	deleteField,
@@ -170,21 +170,49 @@ export const itemService = {
 		} else {
 			const remoteDb = window.db.getDb();
 
-			const batch = writeBatch(remoteDb);
-			/* eslint-disable guard-for-in */
-			for (var id in items) {
-				items[id].createdBy = window.user.uid;
-				batch.set(doc(remoteDb, `items/${id}`), items[id]);
-				batch.update(doc(remoteDb, `users/${window.user.uid}`), {
-					[`items.${id}`]: true
-				});
-
-				// Set these items on our cached user object too
-				window.user.items = window.user.items || {};
-				window.user.items[id] = true;
+			function save(items) {
+				const batch = writeBatch(remoteDb);
+				/* eslint-disable guard-for-in */
+				for (var id in items) {
+					items[id].createdBy = window.user.uid;
+					batch.set(doc(remoteDb, `items/${id}`), items[id]);
+					batch.update(doc(remoteDb, `users/${window.user.uid}`), {
+						[`items.${id}`]: true
+					});
+				}
+				return batch.commit();
+				/* eslint-enable guard-for-in */
 			}
-			batch.commit().then(d.resolve);
-			/* eslint-enable guard-for-in */
+
+			function onSuccess(items) {
+				window.user.items = window.user.items || {};
+				for (var id in items) {
+					// Set these items on our cached user object too
+					window.user.items[id] = true;
+				}
+				d.resolve();
+			}
+
+			save(items)
+				.then(() => {
+					onSuccess(items);
+				})
+				.catch(e => {
+					// The only reason we know for this failing is the same creations were
+					// imported in other account. And hence they can't again be saved in the
+					// DB with same ID and different `createdBy`
+					// So now we save them with different IDs
+					log('Saving imported items failed. Trying with refreshed IDs now...');
+					const refreshedItems = refreshItemIds(items);
+					save(refreshedItems)
+						.then(() => {
+							onSuccess(refreshedItems);
+						})
+						.catch(e => {
+							log('Error saving items', e);
+							alert('Your items could not be saved. Please try again later.');
+						});
+				});
 		}
 		return d.promise;
 	},

--- a/src/utils.js
+++ b/src/utils.js
@@ -672,3 +672,16 @@ export function persistAuthUserLocally(user) {
 	keys.map(key => (obj[key] = user[key]));
 	window.localStorage.setItem('user', JSON.stringify(obj));
 }
+
+/**
+ * items is an object of  {itemId: item}. This fn changes all the keys to new item IDs
+ * */
+export function refreshItemIds(items) {
+	const newItems = {};
+	for (var id in items) {
+		const newId = generateRandomId();
+		items[id].id = newId;
+		newItems[newId] = items[id];
+	}
+	return newItems;
+}


### PR DESCRIPTION
lets say you have an exported list of creations. You have those creations already synced to a cloud account. Now if you go to a new account and try to import that exported items, it will fail to sync. Because exported items have their own ID and they already exist in the db with that ID...so cant save them again in the DB with same ID.

So now, if syncing fails here, we refresh all the IDs to new one and then try saving.