### PR TITLE
Quality: removeFileAtPath silently corrupts file tree when file not found (splice with index -1)

### DIFF
--- a/src/fileUtils.js
+++ b/src/fileUtils.js
@@ -88,7 +88,9 @@ export function removeFileAtPath(files, path) {
 	}
 	// now we should be left with just one value in the pathPieces array - the actual file name
 	const { index } = getChildFileFromName(currentFolder, pathPieces[0]);
-	currentFolder.splice(index, 1);
+	if (index !== -1) {
+		currentFolder.splice(index, 1);
+	}
 }
 
 /**


### PR DESCRIPTION
## ✨ Code Quality

### Problem
When the target file does not exist at the given path, `getChildFileFromName` returns `{index: -1, file: undefined}`. The destructured `index` is -1, and `currentFolder.splice(-1, 1)` silently removes the **last** item in the array instead of the intended file. This is silent data corruption — the user deletes a nonexistent path and loses an unrelated file.


**Severity**: `critical`
**File**: `src/fileUtils.js`

### Solution
When the target file does not exist at the given path, `getChildFileFromName` returns `{index: -1, file: undefined}`. The destructured `index` is -1, and `currentFolder.splice(-1, 1)` silently removes the **last** item in the array instead of the intended file. This is silent data corruption — the user deletes a nonexistent path and loses an unrelated file.


### Changes
- `src/fileUtils.js` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #605